### PR TITLE
Added builder.Environment.EnvironmentName as first default fallback

### DIFF
--- a/Proxmea.ILoggerN/SharedLogging.cs
+++ b/Proxmea.ILoggerN/SharedLogging.cs
@@ -19,6 +19,7 @@ namespace Proxmea.ILoggerN
         {
             // Determine environment
             var env = builder.Configuration["AppSettings:Environment"]
+                      ?? builder.Environment?.EnvironmentName
                       ?? Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")
                       ?? Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT")
                       ?? "Development";


### PR DESCRIPTION
Added builder.Environment.EnvironmentName as first default fallback for logging environment since it should be populated by the .NET host creation.